### PR TITLE
Allow setting separate livereload host

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ Key | Type | Default | Description |
 `port` | Number | `8000` | port of the webserver
 `livereload` | Boolean/Object | `false` | whether to use livereload. For advanced options, provide an object.
 `livereload.port` | Number | `35729` | port for livereload server to listen on.
+`livereload.host` | String | `host` | hostname to reference livereload in the markup (to use with pow)
 `livereload.filter` | Function | - | function to filter out files to watch (default filters out `node_modules`).
 `livereload.clientConsole` | Boolean | `false` | whether to capture `window.console` output from the client and send it to the back-end for display.
 `directoryListing` | Boolean/Object | `false` | whether to display a directory listing. For advanced options, provide an object. You can use the `path property to set a custom path or the `options` property to set custom [serve-index](https://github.com/expressjs/serve-index) options.

--- a/src/index.js
+++ b/src/index.js
@@ -83,6 +83,9 @@ module.exports = function(options) {
   // Allow shorthand syntax, using the enable property as a flag
   var config = enableMiddlewareShorthand(defaults, options, ['directoryListing', 'livereload']);
 
+  // If it wasn't provided, use the server host:
+  config.livereload.host = config.livereload.host || config.host;
+
   var openInBrowser = function () {
     if (config.open === false) return;
     open('http' + (config.https ? 's' : '') + '://' + config.host + ':' + config.port);
@@ -110,7 +113,7 @@ module.exports = function(options) {
 
   // socket.io
   if (config.livereload.enable) {
-    var ioServerOrigin = 'http://' + config.host + ':' + config.livereload.port;
+    var ioServerOrigin = 'http://' + config.livereload.host + ':' + config.livereload.port;
 
     var snippetParams = [];
 
@@ -118,11 +121,11 @@ module.exports = function(options) {
       snippetParams.push("extra=capture-console");
     }
 
-    var snippet = 
-      "<script type='text/javascript' async defer src='" 
-      + ioServerOrigin 
-      + "/livereload.js?" 
-      + snippetParams.join('&') 
+    var snippet =
+      "<script type='text/javascript' async defer src='"
+      + ioServerOrigin
+      + "/livereload.js?"
+      + snippetParams.join('&')
       + "'></script>";
 
     app.use(inject({
@@ -183,7 +186,7 @@ module.exports = function(options) {
 
     ioApp.use(serveStatic(BROWSER_SCIPTS_DIR, { index: false }));
 
-    var ioServer = config.livereload.ioServer = 
+    var ioServer = config.livereload.ioServer =
       http.createServer(ioApp).listen(config.livereload.port, config.host);
 
     io.attach(ioServer, {


### PR DESCRIPTION
Hi,

Thank you for your work. I'm in a situation where I'd like live reload to reference a separate host other than the default. This is in order to be able to live reload apps via a local network.

This change introduces a new configuration option (with the current value as the default) to set just that.
