### PR TITLE
Add fallback match rules for html script injection

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -119,7 +119,7 @@ module.exports = function(options) {
     }
 
     // If it wasn't provided, use the server host:
-    var markupHost = !!_.get(config.livereload.markupHost, 'length') 
+    var markupHost = !!_.get(config.livereload.markupHost, 'length')
       ? "'" + config.livereload.markupHost + "'"
       : null;
 
@@ -132,13 +132,25 @@ module.exports = function(options) {
       + "document.body.appendChild(_lrscript);"
       + "</script>";
 
+    var prepend = function(w, s) {
+      return s + w;
+    };
+
+    var append = function(w, s) {
+      return w + s;
+    }
+
     app.use(inject({
       snippet: snippet,
       rules: [{
         match: /<\/body>/,
-        fn: function(w, s) {
-          return s + w;
-        }
+        fn: prepend
+      }, {
+        match: /<\/html>/,
+        fn: prepend
+      }, {
+        match: /<\!DOCTYPE.+>/,
+        fn: append
       }]
     }));
 


### PR DESCRIPTION
Currently we're only looking for a closing `body` tag to determine if and where the livereload snippet should be injected. However, it's perfectly valid in html5 to omit the `body` or even the `html` tag.

As per the example from [connect-inject](https://www.npmjs.com/package/connect-inject#options) I've added rules to match either the closing `html` tag or to inject the snippet directly after the `DOCTYPE` declaration if either are missing.

**N.B.** Tested and working locally. I tried to implement proper tests, but I couldn't get the scripts to inject at all through the test suite.
