### PR TITLE
Update README.md for fallbackLogic example

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,10 +215,8 @@ gulp.task('webserver', function() {
   gulp.src('app')
     .pipe(server({
       fallback: 'index.html',
-      fallbackConfig: function(req, res, fallbackFile) {
-        var parsedUrl = url.parse(req.url);
-
-        if (0 < parsedUrl.pathname.indexOf('.png')) {
+      fallbackLogic: function(req, res, fallbackFile) {
+        if (req.url.match(/\.png$/i)) {
           res.statusCode = 404;
           res.end();
         } else {


### PR DESCRIPTION
Example code had fallbackConfig property, which was probably renamed. Also simplified the matching logic.
