### PR TITLE
Fix chrome livereload

### DIFF
--- a/src/browser-scripts/livereload.js
+++ b/src/browser-scripts/livereload.js
@@ -6,8 +6,7 @@
     require = define = null;
   }
 
-
-  var __consoleLog = window.console.log;
+  var __consoleLog = window.console.log.bind(window.console);
   var __log = function(msg) {
     __consoleLog('LIVERELOAD: ' + msg);
   };


### PR DESCRIPTION
Livereload does not work in chrome because of the illegal call to the window.console.log function. Log function in chrome is context aware (sensitive to the current value of 'this'). This commit fixes this chrome related bug by calling window.console.log directly, and hence in the right context.
