### PR TITLE
Fix #44: We no longer nuke the global logging when this plugin is loaded.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,6 @@
 var _ = require('lodash'),
   through = require('through2'),
   gutil = require('gulp-util'),
-  gulpLogger = require('gulplog'),
   glogg = require('glogg'),
   http = require('http'),
   https = require('https'),
@@ -20,7 +19,6 @@ var _ = require('lodash'),
   socket = require('socket.io'),
   url = require('url'),
   extend = require('node.extend');
-
 
 var BROWSER_SCIPTS_DIR = path.join(__dirname, 'browser-scripts');
 
@@ -47,7 +45,7 @@ function bindLogger(logLevel, kind) {
     })
     .forEach(function (level) {
       logger.on(level, function () {
-        gulpLogger.info.apply(gulpLogger, arguments);
+        gutil.log.apply(gutil.log, arguments);
       });
     });
 


### PR DESCRIPTION
Whoops. Sorry guys!

We no longer nuke the global logging when this plugin is loaded.

This was caused by `require('gulplog')` - this caused it to create the global gulp logging sparkle context with no events hooked up.

Fixes #44 
